### PR TITLE
feat: Set up daphne/channels for Django

### DIFF
--- a/backend/main/asgi.py
+++ b/backend/main/asgi.py
@@ -9,8 +9,13 @@ https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
 
 import os
 
+from channels.routing import ProtocolTypeRouter
 from django.core.asgi import get_asgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'main.settings')
 
-application = get_asgi_application()
+application = ProtocolTypeRouter(
+    {
+        'http': get_asgi_application(),
+    }
+)

--- a/backend/main/settings.py
+++ b/backend/main/settings.py
@@ -32,6 +32,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'daphne',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -74,6 +75,9 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'main.wsgi.application'
+
+# Daphne/Channels
+ASGI_APPLICATION = 'main.asgi.application'
 
 
 # Database

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,3 @@
 django==5.0.7
+channels==4.1.0
+daphne==4.1.2


### PR DESCRIPTION
To further elaborate, `daphne` is a websocket server that comes with `channels`, both of which are modules developed by the Django team.
The reason as to why we have to use daphne/channels is because Django on its own doesn't support websockets.
This is where `daphne` comes in, `daphne` is basically just a websocket server built specifically to run alongside Django.
At the moment, no websocket addresses/URLs are allowed, as the configuration for that hasn't been set up yet.

**tl;dr:** this PR just sets up daphne to run alongside Django