### PR TITLE
Refactor Makefile rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@ DC		=	docker compose -f
 YAML	=	docker-compose.yml
 RMRF	=	sudo rm -rf
 
-up: build
+all: build up
+re: fclean all
+
+up:
 		$(DC) $(YAML) up -d
 
 build:
@@ -11,19 +14,12 @@ build:
 
 down:
 		$(DC) $(YAML) down
-all:
-		$(DC) $(YAML) up -d --build
 
 cclean:
 		docker system prune --all --volumes --force
 
-fclean:
-		docker stop $$(docker ps -qa);
-		docker rm $$(docker ps -qa); \
+fclean: down
 		docker rmi -f $$(docker images -qa); \
 		docker volume rm $$(docker volume ls -q); \
-		docker network ls -q | grep -v -E 'bridge|host|none' | xargs -r docker network rm;
-
-re: fclean up
 
 .PHONY:	all down fclean re build cclean up

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ If you want to clean up the images and rebuild at the same time, run:
 make re
 ```
 
+### Summary of Makefile rules
+```yaml
+all: (default) Builds and runs the containers.
+re: Similar to "all" but removes containers, images, and volumes.
+up: Runs the containers in the background.
+down: Stops and removes containers running in the background (including networks)
+cclean: Purges EVERYTHING Docker related, including cache and stuff. Use with caution.
+fclean: Attempts to remove everything created by the containers (including volumes and images)
+```
+
 ______
 ## Running Django without Docker
 > This is only useful if you don't want to bother with using Docker to run Django.


### PR DESCRIPTION
Refactors the Makefile rules, and updates the README with relevant info
### Changes
- `all`: just calls the rules `build` and `up` now (also the default rule now)
- `up`: doesn't call `build` anymore, so you don't have to always rebuild
- `fclean`: `docker compose down` already removes containers and networks