### PR TITLE
Add nginx

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY . .
 RUN pip install -r requirements.txt
 
-CMD ["python", "manage.py", "runserver"]
+CMD ["python", "manage.py", "runserver", "0.0.0.0:3000"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY . .
 RUN pip install -r requirements.txt
 
-CMD ["python", "manage.py", "runserver", "0.0.0.0:3000"]
+CMD ["daphne", "-p3000", "-b0.0.0.0", "main.wsgi:application"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY . .
 RUN pip install -r requirements.txt
 
-CMD ["daphne", "-p3000", "-b0.0.0.0", "main.wsgi:application"]
+CMD ["daphne", "-p3000", "-b0.0.0.0", "main.asgi:application"]

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -18,8 +18,16 @@ http {
 
         location @daphne-proxy {
             proxy_pass http://daphne;
-            # include uwsgi_params;
-            # uwsgi_pass django:3000;
+
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_redirect off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $server_name;
         }
     }
 }

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -1,0 +1,25 @@
+events {}
+
+http {
+    upstream daphne {
+        server django:3000;
+    }
+
+    server {
+        listen 8000;
+
+        root /var/www/html;
+        index index.html;
+        include mime.types;
+
+        location / {
+            try_files $uri @daphne-proxy;
+        }
+
+        location @daphne-proxy {
+            proxy_pass http://daphne;
+            # include uwsgi_params;
+            # uwsgi_pass django:3000;
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     ports:
       - 3000:3000
     networks:
-      - backend_net
+      - django_net
+      - db_net
     # volumes:
     env_file:
       - .env
@@ -17,8 +18,23 @@ services:
     ports:
       - 8080:8080
     networks:
-      - backend_net
+      - db_net
     # volumes:
+    env_file:
+      - .env
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27.0-alpine
+    ports:
+      - 8000:8000
+    networks:
+      - django_net
+    depends_on:
+      - django
+    volumes:
+      - ./frontend:/var/www/html
+      - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf
     env_file:
       - .env
     restart: unless-stopped
@@ -27,4 +43,5 @@ volumes:
   data:
 
 networks:
-  backend_net:
+  django_net:
+  db_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   django:
     build: ./backend
-    ports:
-      - 3000:3000
     networks:
       - django_net
       - db_net
@@ -15,8 +13,6 @@ services:
 
   postgresql:
     image: postgres:16-alpine
-    ports:
-      - 8080:8080
     networks:
       - db_net
     # volumes:


### PR DESCRIPTION
Adds an nginx container to Docker Compose, which is used to help serve static files to the user.
Additionally, data will also be routed to the Django backend for processing if needed.
That said, as of writing this, the Docker Compose structure isn't properly set up for Django to actually serve templates.

Additional note: This PR also changes how the Django Docker runs, where instead of using `./manage.py runserver`, now it uses `daphne -p3000 -b0.0.0.0 main.asgi:application`
This is because the former method is actually meant for debugging purposes only, so it doesn't really run well in production.
tl;dr: django docker now uses daphne directly to run