### PR TITLE
Fix Docker(nginx) static files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ DC		=	docker compose -f
 YAML	=	docker-compose.yml
 RMRF	=	sudo rm -rf
 
-all: build up
+all: down build up
+reload: down up
 re: fclean all
 
 up:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ make re
 
 ### Summary of Makefile rules
 ```yaml
-all: (default) Builds and runs the containers.
+all: (default) Stops, builds, and runs the containers.
+reload: Restarts the containers.
 re: Similar to "all" but removes containers, images, and volumes.
 up: Runs the containers in the background.
 down: Stops and removes containers running in the background (including networks)
@@ -71,7 +72,7 @@ If you don't know what that is, look up `venv`.
 $ cd backend
 
 # Then install the backend dependencies
-$ pip install -r ./backend/requirements.txt
+$ pip install -r ./requirements.txt
 
 # After that, start up django
 $ ./manage.py runserver

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -12,6 +12,10 @@ http {
         index index.html;
         include mime.types;
 
+        location /static/ {
+            alias /var/www/html/;
+        }
+
         location / {
             try_files $uri $uri/index.html @daphne-proxy;
         }

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -13,7 +13,7 @@ http {
         include mime.types;
 
         location / {
-            try_files $uri @daphne-proxy;
+            try_files $uri $uri/index.html @daphne-proxy;
         }
 
         location @daphne-proxy {


### PR DESCRIPTION
Fixes the Docker container (specifically nginx) not serving `index.html` as the default path (whereas `/index.html` worked)

Additionally, fixed some documentation issues and added Makefile rule `reload` (which just runs `down` and `up`)
Also `all` now runs `down` before building, because apparently `up` doesn't always reload containers that are running