### PR TITLE
fix(docker): properly set up django's database via migrate

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,5 +2,6 @@ FROM python:3.12-alpine
 WORKDIR /app
 COPY . .
 RUN pip install -r requirements.txt
+RUN python manage.py migrate
 
 CMD ["daphne", "-p3000", "-b0.0.0.0", "main.asgi:application"]


### PR DESCRIPTION
Runs `python manage.py migrate` to create the database that django needs to run