### PR TITLE
feat: Add .env template file

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,8 @@
+# django
+DJANGO_DEBUG=false
+DJANGO_JWT_SECRET_KEY=
+
+# postgresql
+POSTGRES_DB=django
+POSTGRES_USER=
+POSTGRES_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ Docker, docker-compose, Makefile
 
 ______
 ## Docker Setup
-If you just want to get stuff up and running, just run the following:
+Before you do anything, copy `.env.template` and make a `.env` file. (make sure this is in the same directory as the `docker-compose.yml` file)
+Make sure to also fill in the empty values.
+
+After that, you can just run the following to get stuff up and running:
 ```sh
 make
 ```

--- a/README.md
+++ b/README.md
@@ -74,9 +74,6 @@ $ cd backend
 # Then install the backend dependencies
 $ pip install -r ./requirements.txt
 
-# After that, start up django
-$ ./manage.py runserver
-
-# alternatively
-$ python manage.py runserver
+# After that, start up django with the devrun script
+$ ./devrun.sh
 ```

--- a/backend/devrun.sh
+++ b/backend/devrun.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+BASEDIR=$(dirname "$0")
+if [ ! -f "${BASEDIR}/../.env" ]
+then
+	echo ".env file not found at root directory, please create one."
+	exit
+fi
+
+export $(cat "${BASEDIR}/../.env" | sed -e 's/#.*$//' | xargs)
+export DJANGO_DEBUG=true
+echo "Starting Django server with debug mode enabled..."
+$BASEDIR/manage.py runserver

--- a/backend/main/settings.py
+++ b/backend/main/settings.py
@@ -13,6 +13,18 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 from pathlib import Path
 import os
 
+# because os.environ's exception isn't that descriptive
+def getenv_and_validate(name):
+    value = os.getenv(name)
+
+    if value == None:
+        raise KeyError('Environment variable "' + name + '" does not exist')
+
+    elif value == '':
+        raise ValueError('Environment variable "' + name + '" has an empty value')
+
+    return value
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
@@ -22,10 +34,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'django-insecure-8(*2i*l0##=#g-=_d#%6tr!&i%20(ng%&9jiad!si-oa&ohex_'
-JWT_SECRET_KEY = 'applebananasgreenmonkey123'
+JWT_SECRET_KEY = getenv_and_validate('DJANGO_JWT_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
+if os.getenv('DJANGO_DEBUG', 'false').lower() in ['false', '']:
+    DEBUG = False
 
 ALLOWED_HOSTS = []
 


### PR DESCRIPTION
Note: this does break the Django Dockerfile image as it tries to migrate while building, and environmental variables are not shared while building. Though this doesn't really matter since the Django Dockerfile shouldn't be migrating while building anyways. This issue will be fixed in another PR. (see #23)

Adds a `.env.template` file for easy `.env` file creation :]
Additionally, `settings.py` has a new function: `getenv_and_validate(name)`, basically it raises an exception if an environment variable is empty or non-existent.

Also adds a new script, `devrun.sh`, to let you run the dev server with the .env file loaded.