### PR TITLE
fix(docker): only run django migrations after docker is built

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-alpine
 WORKDIR /app
 COPY . .
+RUN chmod +x docker-entrypoint.sh
 RUN pip install -r requirements.txt
-RUN python manage.py migrate
 
-CMD ["daphne", "-p3000", "-b0.0.0.0", "main.asgi:application"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+python manage.py migrate
+daphne -p3000 -b0.0.0.0 "main.asgi:application"


### PR DESCRIPTION
who knew running migrations while building isn't really a good idea lol