### PR TITLE
fix(django): make devrun.sh a .env wrapper for manage.py 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ A quick preface:
 I recommend using a Python environment before doing the following steps.
 If you don't know what that is, look up `venv`.
 
+NOTE: use `devrun.sh` instead of `manage.py`, this script will automatically load the .env in the root directory, which `main/settings.py` needs to work
+
 ```sh
 # First, make sure your current directory is in "./backend"
 $ cd backend
@@ -78,5 +80,5 @@ $ cd backend
 $ pip install -r ./requirements.txt
 
 # After that, start up django with the devrun script
-$ ./devrun.sh
+$ ./devrun.sh runserver
 ```

--- a/backend/devrun.sh
+++ b/backend/devrun.sh
@@ -9,5 +9,5 @@ fi
 
 export $(cat "${BASEDIR}/../.env" | sed -e 's/#.*$//' | xargs)
 export DJANGO_DEBUG=true
-echo "Starting Django server with debug mode enabled..."
-$BASEDIR/manage.py runserver
+echo "Running manage.py with debug mode forcefully enabled..."
+$BASEDIR/manage.py $1


### PR DESCRIPTION
basically, instead of doing "runserver", just act as a wrapper for manage.py