### PR TITLE
feat(django): add channel layers for websocket communications

### DIFF
--- a/backend/main/settings.py
+++ b/backend/main/settings.py
@@ -95,6 +95,23 @@ WSGI_APPLICATION = 'main.wsgi.application'
 # Daphne/Channels
 ASGI_APPLICATION = 'main.asgi.application'
 
+if DEBUG:
+    CHANNEL_LAYERS = {
+        'default': {
+            'BACKEND': 'channels.layers.InMemoryChannelLayer'
+        }
+    }
+
+else:
+    CHANNEL_LAYERS = {
+        'default': {
+            'BACKEND': 'channels_redis.core.RedisChannelLayer',
+            'CONFIG': {
+                'hosts': [('127.0.0.1', 6379)]
+            },
+        }
+    }
+
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases


### PR DESCRIPTION
This is required to allow Consumers to communicate with each other.
Additionally, you can also access this via `get_channel_layer()` to communicate with Consumers outside of a Consumer class.

See here for more info: https://channels.readthedocs.io/en/latest/topics/channel_layers.html