### PR TITLE
feat: Add Redis service for Channel Layers usage in Docker

### DIFF
--- a/backend/main/settings.py
+++ b/backend/main/settings.py
@@ -41,7 +41,7 @@ DEBUG = True
 if os.getenv('DJANGO_DEBUG', 'false').lower() in ['false', '']:
     DEBUG = False
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['0.0.0.0', 'localhost', '127.0.0.1']
 
 
 # Application definition
@@ -107,7 +107,7 @@ else:
         'default': {
             'BACKEND': 'channels_redis.core.RedisChannelLayer',
             'CONFIG': {
-                'hosts': [('127.0.0.1', 6379)]
+                'hosts': [('redis', 6379)]
             },
         }
     }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 django==5.0.7
 channels==4.1.0
+channels-redis==4.2.0
 daphne==4.1.2
 pyjwt==2.3.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,24 @@ services:
     build: ./backend
     networks:
       - django_net
+      - redis_net
       - db_net
     # volumes:
     env_file:
       - .env
     depends_on:
+      - redis
       - postgresql
     restart: unless-stopped
+
+  redis:
+    image: redis:7.4-alpine
+    networks:
+      - redis_net
+    ulimits:
+      nofile:
+        soft: 10032
+        hard: 10032
 
   postgresql:
     image: postgres:16-alpine
@@ -40,4 +51,5 @@ volumes:
 
 networks:
   django_net:
+  redis_net:
   db_net:


### PR DESCRIPTION
This is important as the built-in `In-Memory Channel Layer` module is only meant for development usage, and, according to the docs, has a lot of issues that don't really work well for a non-development environment (one of those issues being memory leaks)

see here for more info on the type of Channel Layers usable:
https://channels.readthedocs.io/en/stable/topics/channel_layers.html#configuration
(note: there is a [postgresql channel layers](https://github.com/danidee10/channels_postgres/), but it's not official, and i don't think using postgresql for caching data is that efficient)

Also, quick explanation on what Redis is:
Redis describes itself as a "NoSQL database", meaning that it doesn't store any data in the local storage, and instead stores it all in memory. Additionally, the data is stored in a key-value structure, aka a Dictionary; hence the full name "Remote Dictionary Server" (what a weird abbreviation)
This makes Redis good for quick low-latency reads and writes, making it suitable and efficient for caching data; which is what it's being used for in Django Channels. (iirc, it's mainly being used for storing Channel Layers data; e.g: groups, layers, channels, messages, etc.)

### Changes:
- Added Redis service
- Added new Django dependency, `channels-redis`
- `ALLOWED_HOSTS` is now configured somewhat, so debug mode can be disabled now
- Fixed `CHANNEL_LAYERS` using the wrong Redis IP address
