### PR TITLE
fix: use "$@" to accept arguments in devrun.sh

### DIFF
--- a/backend/devrun.sh
+++ b/backend/devrun.sh
@@ -10,4 +10,4 @@ fi
 export $(cat "${BASEDIR}/../.env" | sed -e 's/#.*$//' | xargs)
 export DJANGO_DEBUG=true
 echo "Running manage.py with debug mode forcefully enabled..."
-python3 $BASEDIR/manage.py $1
+python3 $BASEDIR/manage.py "$@"


### PR DESCRIPTION
specifically `"$@"` and not `$@` because `"$@"` properly handles strings.