### PR TITLE
chore(token): more detailed error messages to remove confusion

### DIFF
--- a/frontend/src/js/network_utils/token_utils.js
+++ b/frontend/src/js/network_utils/token_utils.js
@@ -2,16 +2,28 @@ import { postRequest } from "./api_requests.js";
 
 export async function verifyToken() {
   const response = await fetch('/api/token/verify/', { method: 'POST' })
-  if (!response.ok)
-    console.log('token: could not verify token!')
+  if (!response.ok) {
+    const contents = await response.json()
+    if ('detail' in contents) {
+      console.log(`token: ${contents.detail}`)
+    } else if (response.status != 500) {
+      console.log('token: no access token found in local storage')
+    }
+  }
 
   return response.ok
 }
 
 export async function refreshToken() {
   const response = await fetch('/api/token/refresh/', { method: 'POST' })
-  if (!response.ok)
-    console.log('token: could not refresh token!')
+  if (!response.ok) {
+    const contents = await response.json()
+    if ('detail' in contents) {
+      console.log(`token: ${contents.detail}`)
+    } else if (response.status != 500) {
+      console.log('token: no refresh token found in local storage')
+    }
+  }
 
   return response.ok
 }


### PR DESCRIPTION
turns out, only saying `could not verify/refresh token` is very confusing