### PR TITLE
fix(requirements): add tzdata if python doesn't have it for some reason

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ redis==5.1.1
 pytz==2024.2
 django-redis==5.4.0
 adrf==0.1.8
+tzdata==2024.2


### PR DESCRIPTION
this is required for timezones to work